### PR TITLE
M02 normalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 *.deb
+*.html
+*.csv
+# keep normalized CSVs
+!*_normalized.csv

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10.0
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Repository Setup Guide
 
-## Requirements (Starting Point)
+### Requirements (Starting Point)
 - A fresh VM (Linux-based, e.g. Ubuntu 20.04+).
 - GitHub SSH key configured for access.
 - Git installed (`git --version`).
@@ -31,6 +31,12 @@ env:
 
 update:	env
 	. env/bin/activate; pip install -r requirements.txt
+
+test:
+	./env/bin/pytest
+
+lint:
+	./env/bin/pylint . --ignore=env
 
 Ensure you are using tab for spacing and not the spacebar as this could make an error message.
 
@@ -78,7 +84,7 @@ CTRL+X to exit
 Enter to return to bash
 
 
-## Headless Chrome Setup
+### Headless Chrome Setup
 
 This repo includes a helper script to install Google Chrome (headless) on Ubuntu.
 
@@ -145,10 +151,54 @@ Checking the outputs:
 head ygainers_normalized.csv
 head wsjgainers_normalized.csv
 
-##Noted
 
+##Noted
+"""
 .gitignore is set up to exclude raw .html and .csv scrape files, but keeps the normalized outputs (*_normalized.csv).
 
 WSJ and Yahoo may change their table column names. If parsing fails, inspect the columns:
 python -c "import pandas as pd; print(pd.read_csv('wsjgainers.csv').columns)"
+"""
 
+### Linting and Testing
+
+We will use **pylint** for code styling checks and **pytest** for testing the code.
+
+---
+
+## Setup
+Make sure your virtual environment is created and dependencies installed:
+
+```bash
+make update
+
+Check your make file to ensure that pylint and pytest have been added (see above for makefile)
+
+## Step 1 
+pylint uses the .pylintrc configuration file, from the root of the directory (the directory that
+has your makefile) run pylint --generate-rcfile >> pylintrc, this will greate the config file which
+you can edit by accessing it with nano.
+
+Now run make lint, this will do a test and will provide some sample out puts like unused imports,
+missing docstrings, or lines that are too long.
+
+## Step 2
+To create a test file in bash make a repository called tests then create the test file inside:
+tests/test_<name for test>.py
+
+Make test will run all tests or you can fun pytest directly with ./env/bin/pytest -v
+** -vvx will provide more information but stop the test at the first fail**
+
+## Step 3
+Access the test file and create your test functions:
+
+In this file we created 2 functions one to test the python version and on to test the os version
+
+Once these are save you can run make test in bash to test your files
+
+## NOTES
+Always run linting before committing to keep code clean.
+
+Add new tests whenever you add new features or fix bugs.
+
+ 

--- a/README.md
+++ b/README.md
@@ -91,3 +91,64 @@ bash scripts/install_chrome_headless.sh
 google-chrome-stable --version
 google-chrome-stable --headless --no-sandbox --disable-gpu --dump-dom https://example.com | head
 
+## Normalizer function
+
+This project provides a script to normalize stock gainer tables scraped from:
+
+Yahoo Finance (top gainers)
+
+Wall Street Journal (WSJ) (U.S. movers)
+
+The normalizer will output a more legiable CSV file containing the schemas: symbol, company_name, price, change, perc_change, volume
+
+## Step 1
+Clone the repository and install python
+ 
+git clone git@github.com:ChelseyB-UVA/2508_DS5111_qck2qg.git
+cd 2508_DS5111_qck2qg
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+
+Then  clone the repository 2508_DS5111_materials/scripts/ into your scripts file
+Then clone the repository 2508_DS5111_materials/scripts/Makefile into your scripts file
+
+## Step 2
+Collect the raw data using the makefiles in bash
+
+make ygainers.csv
+make wsjgainers.csv
+
+##Step 3
+Build  the .py file to house the functions needed to normalize the data
+
+nano bin.normalize_gainers.py
+
+once functions are written and saved then pull python to run
+
+##Step 4 
+Test the functions:
+
+python bin/normalize_gainers.py
+
+if scripts are correct it should produce
+yganiers_normalized.csv
+wsjgainers_normalized.csv
+
+I tested the script by:
+
+Generating raw CSVs (make ygainers.csv, make wsjgainers.csv).
+
+Running the normalizer (python bin/normalize_gainers.py).
+
+Checking the outputs:
+head ygainers_normalized.csv
+head wsjgainers_normalized.csv
+
+##Noted
+
+.gitignore is set up to exclude raw .html and .csv scrape files, but keeps the normalized outputs (*_normalized.csv).
+
+WSJ and Yahoo may change their table column names. If parsing fails, inspect the columns:
+python -c "import pandas as pd; print(pd.read_csv('wsjgainers.csv').columns)"
+

--- a/README.md
+++ b/README.md
@@ -78,3 +78,16 @@ CTRL+X to exit
 Enter to return to bash
 
 
+## Headless Chrome Setup
+
+This repo includes a helper script to install Google Chrome (headless) on Ubuntu.
+
+### Run the installer
+**This repo command  was cloned from 2508_DS5111_materials/scripts/ **
+```bash
+bash scripts/install_chrome_headless.sh
+
+### Verify it works
+google-chrome-stable --version
+google-chrome-stable --headless --no-sandbox --disable-gpu --dump-dom https://example.com | head
+

--- a/bin/normalize_gainers.py
+++ b/bin/normalize_gainers.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+import pandas as pd
+
+
+def normalize_yahoo(csv_path, out_path=None):
+    df = pd.read_csv(csv_path)
+
+    # Example: "7.93 +3.40 (75.06%)"
+    parts = df["Price"].astype(str)
+    df["price"] = parts.str.split().str[0]
+    df["change"] = parts.str.split().str[1]
+    df["perc_change"] = parts.str.extract(r"\(([-+]?\d+\.?\d*)%")
+
+    out = df.rename(columns={"Symbol": "symbol", "Name": "company_name", "Volume": "volume"})[
+        ["symbol", "company_name", "price", "change", "perc_change", "volume"]
+    ]
+
+    out_path = Path(out_path or "ygainers_normalized.csv")
+    out.to_csv(out_path, index=False)
+    return out_path
+
+
+def normalize_wsj(csv_path, out_path=None):
+    df = pd.read_csv(csv_path)
+
+    # --- pick the "company (TICKER)" column ---
+    candidates = ["Company", "Name", "Unnamed: 0"]
+    comp_col = next((c for c in candidates if c in df.columns), None)
+    if comp_col is None:
+        # fallback: first column, or any column containing "(TICKER)"
+        comp_col = df.columns[0]
+        if not df[comp_col].astype(str).str.contains(r"\([A-Z\.]+\)\s*$").any():
+            for c in df.columns:
+                if df[c].astype(str).str.contains(r"\([A-Z\.]+\)\s*$").any():
+                    comp_col = c
+                    break
+
+    # --- numeric columns (common WSJ variants) ---
+    def pick(names, default=None):
+        for n in names:
+            if n in df.columns:
+                return n
+        return default
+
+    price_col = pick(["Price", "Last", "Last Price"])
+    chg_col   = pick(["Chg", "Change"])
+    pct_col   = pick(["% Chg", "% Change", "Percent Change"])
+    vol_col   = pick(["Volume", "Vol", "Vol."])
+
+    if not all([price_col, chg_col, pct_col, vol_col]):
+        raise ValueError(f"Couldn't find expected columns. Have: {list(df.columns)}")
+
+    # --- extract symbol + clean company name ---
+    rex = r"\(([A-Z\.]+)\)\s*$"
+    df["symbol"] = df[comp_col].astype(str).str.extract(rex, expand=False)
+    df["company_name"] = df[comp_col].astype(str).str.replace(r"\s*\([A-Z\.]+\)\s*$", "", regex=True).str.strip()
+    df = df.dropna(subset=["symbol"]).copy()
+
+    # --- coerce numerics ---
+    def to_float(x):
+        s = str(x).strip().replace(",", "").replace("$", "").replace("%", "")
+        try:
+            return float(s)
+        except Exception:
+            return None
+
+    df["price"] = df[price_col].map(to_float)
+    df["change"] = df[chg_col].map(to_float)
+    df["perc_change"] = df[pct_col].map(to_float)
+    df["volume"] = df[vol_col].astype(str).str.strip().str.upper()
+
+    out = df[["symbol", "company_name", "price", "change", "perc_change", "volume"]]
+    out_path = Path(out_path or "wsjgainers_normalized.csv")
+    out.to_csv(out_path, index=False)
+    return out_path
+
+
+if __name__ == "__main__":
+    # Quick manual test (expects ygainers.csv and wsjgainers.csv in CWD)
+    print("Normalizing Yahoo ->", normalize_yahoo("ygainers.csv"))
+    print("Normalizing WSJ   ->", normalize_wsj("wsjgainers.csv"))
+

--- a/bin/normalize_gainers.py
+++ b/bin/normalize_gainers.py
@@ -1,69 +1,87 @@
 #!/usr/bin/env python3
-import re
+"""Normalize gainer data from WSJ/Yahoo sources."""
+
 from pathlib import Path
 import pandas as pd
 
 
-def normalize_yahoo(csv_path, out_path=None):
+def normalize_yahoo(csv_path: str | Path, out_path: str | Path | None = None) -> Path:
+    """Normalize a Yahoo Finance gainers CSV to a standard schema.
+
+    Returns the output path.
+    """
     df = pd.read_csv(csv_path)
 
-    # Example: "7.93 +3.40 (75.06%)"
-    parts = df["Price"].astype(str)
-    df["price"] = parts.str.split().str[0]
-    df["change"] = parts.str.split().str[1]
-    df["perc_change"] = parts.str.extract(r"\(([-+]?\d+\.?\d*)%")
+    # Example "Price" cell: "7.93 +3.40 (75.06%)"
+    parts = df["Price"].astype(str).str.split()
 
-    out = df.rename(columns={"Symbol": "symbol", "Name": "company_name", "Volume": "volume"})[
-        ["symbol", "company_name", "price", "change", "perc_change", "volume"]
-    ]
+    df["price"] = parts.str[0]
+    df["change"] = parts.str[1]
+    df["perc_change"] = df["Price"].astype(str).str.extract(r"\(([-+]?\d+(?:\.\d+)?)%")
+
+    out = df.rename(
+        columns={"Symbol": "symbol", "Name": "company_name", "Volume": "volume"}
+    )[["symbol", "company_name", "price", "change", "perc_change", "volume"]]
 
     out_path = Path(out_path or "ygainers_normalized.csv")
     out.to_csv(out_path, index=False)
     return out_path
 
 
-def normalize_wsj(csv_path, out_path=None):
+def normalize_wsj(csv_path: str | Path, out_path: str | Path | None = None) -> Path:
+    """Normalize a WSJ gainers CSV to a standard schema.
+
+    Returns the output path.
+    """
     df = pd.read_csv(csv_path)
 
-    # --- pick the "company (TICKER)" column ---
+    # --- Pick the "company (TICKER)" column ---
     candidates = ["Company", "Name", "Unnamed: 0"]
     comp_col = next((c for c in candidates if c in df.columns), None)
+
     if comp_col is None:
-        # fallback: first column, or any column containing "(TICKER)"
         comp_col = df.columns[0]
-        if not df[comp_col].astype(str).str.contains(r"\([A-Z\.]+\)\s*$").any():
+        has_ticker = df[comp_col].astype(str).str.contains(r"\([A-Z.]+\)\s*$")
+        if not has_ticker.any():
             for c in df.columns:
-                if df[c].astype(str).str.contains(r"\([A-Z\.]+\)\s*$").any():
+                if df[c].astype(str).str.contains(r"\([A-Z.]+\)\s*$").any():
                     comp_col = c
                     break
 
-    # --- numeric columns (common WSJ variants) ---
-    def pick(names, default=None):
+    # --- Numeric columns (common WSJ variants) ---
+    def pick(names: list[str], default: str | None = None) -> str | None:
         for n in names:
             if n in df.columns:
                 return n
         return default
 
     price_col = pick(["Price", "Last", "Last Price"])
-    chg_col   = pick(["Chg", "Change"])
-    pct_col   = pick(["% Chg", "% Change", "Percent Change"])
-    vol_col   = pick(["Volume", "Vol", "Vol."])
+    chg_col = pick(["Chg", "Change", "Change Net"])
+    pct_col = pick(["% Chg", "Change %", "Chg %"])
+    vol_col = pick(["Volume", "Vol", "Vol."])
 
-    if not all([price_col, chg_col, pct_col, vol_col]):
+    if not all([price_col, chg_col, pct_col, vol_col, comp_col]):
         raise ValueError(f"Couldn't find expected columns. Have: {list(df.columns)}")
 
-    # --- extract symbol + clean company name ---
-    rex = r"\(([A-Z\.]+)\)\s*$"
-    df["symbol"] = df[comp_col].astype(str).str.extract(rex, expand=False)
-    df["company_name"] = df[comp_col].astype(str).str.replace(r"\s*\([A-Z\.]+\)\s*$", "", regex=True).str.strip()
+    # --- Extract symbol + clean company name ---
+    rex_symbol = r"\(([A-Z.]+)\)\s*$"
+    df["symbol"] = df[comp_col].astype(str).str.extract(rex_symbol, expand=False)
+
+    df["company_name"] = (
+        df[comp_col]
+        .astype(str)
+        .str.replace(r"\s*\([A-Z.]+\)\s*$", "", regex=True)
+        .str.strip()
+    )
+
     df = df.dropna(subset=["symbol"]).copy()
 
-    # --- coerce numerics ---
+    # --- Coerce numerics ---
     def to_float(x):
         s = str(x).strip().replace(",", "").replace("$", "").replace("%", "")
         try:
             return float(s)
-        except Exception:
+        except ValueError:
             return None
 
     df["price"] = df[price_col].map(to_float)
@@ -81,4 +99,3 @@ if __name__ == "__main__":
     # Quick manual test (expects ygainers.csv and wsjgainers.csv in CWD)
     print("Normalizing Yahoo ->", normalize_yahoo("ygainers.csv"))
     print("Normalizing WSJ   ->", normalize_wsj("wsjgainers.csv"))
-

--- a/makefile
+++ b/makefile
@@ -10,10 +10,10 @@ update: env
 	bash -c "source env/bin/activate && pip install -r requirements.txt"
 
 test:
-	./env/bin/pytest -vv
+	./env/bin/activate; pytest -vv tests/
 
 lint:
-	./env/bin/pylint . --ignore=env
+	./env/bin/activate; pylint . --ignore=env
 
 linttest: lint test
 	@echo "✅ Linting and tests complete"

--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+
 default:
 	@cat makefile
   
@@ -7,6 +8,12 @@ env:
 update: env
 	. env/bin/activate; pip install -r requirements.txt
 	bash -c "source env/bin/activate && pip install -r requirements.txt"
+
+test:
+	./env/bin/pytest
+
+lint:
+	./env/bin/pylint . --ignore=env
 
 ygainers.html:
 	sudo google-chrome-stable --headless --disable-gpu --dump-dom --no-sandbox --timeout=5000 'https://finance.yahoo.com/markets/stocks/gainers/?start=0&count=200' > ygainers.html
@@ -19,3 +26,4 @@ wsjgainers.html:
 
 wsjgainers.csv: wsjgainers.html
 	python -c "import pandas as pd; raw = pd.read_html('wsjgainers.html'); raw[0].to_csv('wsjgainers.csv')"
+

--- a/makefile
+++ b/makefile
@@ -1,8 +1,21 @@
 default:
 	@cat makefile
-
+  
 env:
 	python3 -m venv env; . env/bin/activate; pip install --upgrade pip
 
 update: env
 	. env/bin/activate; pip install -r requirements.txt
+	bash -c "source env/bin/activate && pip install -r requirements.txt"
+
+ygainers.html:
+	sudo google-chrome-stable --headless --disable-gpu --dump-dom --no-sandbox --timeout=5000 'https://finance.yahoo.com/markets/stocks/gainers/?start=0&count=200' > ygainers.html
+
+ygainers.csv: ygainers.html
+	python -c "import pandas as pd; raw = pd.read_html('ygainers.html'); raw[0].to_csv('ygainers.csv')"
+
+wsjgainers.html:
+	sudo google-chrome-stable --headless --disable-gpu --dump-dom --no-sandbox --timeout=5000 https://www.wsj.com/market-data/stocks/us/movers > wsjgainers.html
+
+wsjgainers.csv: wsjgainers.html
+	python -c "import pandas as pd; raw = pd.read_html('wsjgainers.html'); raw[0].to_csv('wsjgainers.csv')"

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 default:
 	@cat makefile
-  
+
 env:
 	python3 -m venv env; . env/bin/activate; pip install --upgrade pip
 
@@ -10,10 +10,13 @@ update: env
 	bash -c "source env/bin/activate && pip install -r requirements.txt"
 
 test:
-	./env/bin/pytest
+	./env/bin/pytest -vv
 
 lint:
 	./env/bin/pylint . --ignore=env
+
+linttest: lint test
+	@echo "✅ Linting and tests complete"
 
 ygainers.html:
 	sudo google-chrome-stable --headless --disable-gpu --dump-dom --no-sandbox --timeout=5000 'https://finance.yahoo.com/markets/stocks/gainers/?start=0&count=200' > ygainers.html
@@ -26,4 +29,3 @@ wsjgainers.html:
 
 wsjgainers.csv: wsjgainers.html
 	python -c "import pandas as pd; raw = pd.read_html('wsjgainers.html'); raw[0].to_csv('wsjgainers.csv')"
-

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/pylintrc.
+++ b/pylintrc.
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
+
 pandas
 numpy
+lxml
+html5lib
+beautifulsoup4
 pylint
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 numpy
+pylint
+pytest

--- a/scripts/install_chrome_headless.sh
+++ b/scripts/install_chrome_headless.sh
@@ -1,0 +1,12 @@
+# install needed requirements to support chrome's headless browser
+# Install headless browser and run a quick check
+
+sudo apt install fonts-liberation -y
+sudo wget --no-clobber https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo apt install ./google-chrome-stable_current_amd64.deb -y
+sudo apt --fix-broken install
+sudo apt install ./google-chrome-stable_current_amd64.deb -y
+
+# Check Version of chrome and run a quick sanity check
+google-chrome-stable --version
+google-chrome-stable --headless --disable-gpu --dump-dom https://example.com/

--- a/tests/test_smoketests.py
+++ b/tests/test_smoketests.py
@@ -20,4 +20,7 @@ def test_os_version():
     os_version = platform.release()
 
     print(f"Operating System: {os_name} {os_version}")
-    assert True
+
+    # Fail if OS is not one of the expected types
+    expected_os = {"Linux", "Darwin", "Windows"}
+    assert os_name in expected_os, f"Unexpected OS: {os_name}"

--- a/tests/test_smoketests.py
+++ b/tests/test_smoketests.py
@@ -1,0 +1,23 @@
+
+import platform
+import sys
+sys.path.append('.')
+
+import bin.normalize_gainers as nm
+
+def test_of_pytest():
+    assert True
+
+def test_python_version():
+    """Checking the version is 3.10 or newer"""
+    major, minor = sys.version_info[:2]
+    assert (major, minor) >= (3, 10), f"Python {major}.{minor} is to old!"
+    print(f"Python version:{major}.{minor}")
+
+def test_os_version():
+    """Check Operating System (os) name and version."""
+    os_name = platform.system()
+    os_version = platform.release()
+
+    print(f"Operating System: {os_name} {os_version}")
+    assert True

--- a/tests/test_smoketests.py
+++ b/tests/test_smoketests.py
@@ -9,9 +9,9 @@ def test_of_pytest():
     assert True
 
 def test_python_version():
-    """Checking the version is 3.10 or newer"""
+    """Checking the version is 3.12 or newer"""
     major, minor = sys.version_info[:2]
-    assert (major, minor) >= (3, 10), f"Python {major}.{minor} is to old!"
+    assert (major, minor) >= (3, 12), f"Python {major}.{minor} is to old!"
     print(f"Python version:{major}.{minor}")
 
 def test_os_version():
@@ -22,5 +22,5 @@ def test_os_version():
     print(f"Operating System: {os_name} {os_version}")
 
     # Fail if OS is not one of the expected types
-    expected_os = {"Linux", "Darwin", "Windows"}
+    expected_os = {"Linux"}
     assert os_name in expected_os, f"Unexpected OS: {os_name}"

--- a/wsjgainers_normalized.csv
+++ b/wsjgainers_normalized.csv
@@ -1,0 +1,101 @@
+symbol,company_name,price,change,perc_change,volume
+TURB,Turbo Energy S.A. ADR,12.4,9.7,359.26,141.9M
+CHOW,ChowChow Cloud International Holdings Ltd.,12.61,8.61,215.25,1.4M
+FGI,FGI Industries Ltd.,9.5,5.53,139.29,41.4M
+FLUX,Flux Power Holdings Inc.,3.15,1.08,52.17,7.6M
+WBTN,WEBTOON Entertainment Inc.,20.8,5.84,39.04,8.8M
+KLRS,Kalaris Therapeutics Inc.,5.01,1.3,35.04,420.5K
+AEI,Alset Inc.,4.27,1.06,33.02,1.7M
+APLM,Apollomics Inc.,12.18,2.89,31.11,171.4K
+LEE,Lee Enterprises Inc.,5.88,1.36,30.09,593.8K
+GORV,Lazydays Holdings Inc.,3.06,0.61,24.9,27.2M
+AIHS,Senmiao Technology Ltd.,2.67,0.52,24.19,44.7M
+ABTS,Abits Group Inc.,5.39,1.02,23.35,76.8K
+QMMM,QMMM Holdings Ltd. Cl A,88.0,16.25,22.65,575.7K
+HSDT,Helius Medical Technologies Inc.,22.33,4.06,22.22,2.0M
+JMIA,Jumia Technologies AG ADR,11.91,2.12,21.65,13.8M
+QVCGA,QVC Group Inc. Series A,14.42,2.31,19.12,285.6K
+FCHL,Fitness Champs Holdings Ltd.,6.17,0.98,18.88,876.2K
+CHEK,Check-Cap Ltd.,2.52,0.4,18.87,17.8M
+MFH,Mercurity Fintech Holding Inc.,9.54,1.51,18.8,201.6K
+CHNR,China Natural Resources Inc.,5.03,0.78,18.45,105.7K
+SISI,Shineco Inc.,7.76,1.17,17.75,744.0K
+AACG,ATA Creativity Global ADR,2.55,0.38,17.51,193.9K
+CISS,C3is Inc.,2.65,0.39,17.26,325.9K
+SONN,Sonnet BioTherapeutics Holdings Inc.,6.48,0.94,16.97,5.1M
+BBAI,BigBear.ai Holdings Inc.,5.94,0.85,16.7,213.1M
+BITF,Bitfarms Ltd.,2.89,0.41,16.53,156.4M
+PRME,Prime Medicine Inc.,4.67,0.66,16.46,5.1M
+ALMU,Aeluma Inc.,17.11,2.41,16.39,323.1K
+AEHL,Antelope Enterprise Holdings Ltd.,3.34,0.46,15.97,1.1M
+LASE,Laser Photonics Corp.,2.8,0.36,14.75,1.3M
+WAI,Top KingWin Ltd.,3.49,0.44,14.43,359.2K
+AQMS,Aqua Metals Inc.,4.07,0.48,13.53,200.6K
+BLNE,Beeline Holdings Inc.,3.87,0.46,13.49,4.1M
+ENTO,Entero Therapeutics Inc.,4.06,0.47,13.09,393.1K
+LIQT,LiqTech International Inc.,2.83,0.32,12.75,61.6K
+ELTX,Elicio Therapeutics Inc.,11.35,1.27,12.6,59.7K
+NGL,NGL Energy Partners LP,6.47,0.72,12.52,1.2M
+HIT,Health In Tech Inc. Cl A,2.93,0.32,12.26,329.8K
+SKBL,Skyline Builders Group Holding Ltd. Cl A,2.32,0.25,12.08,1.1M
+BWAY,Brainsway Ltd. ADR,16.89,1.79,11.89,220.9K
+NAAS,NaaS Technology Inc. ADR,3.55,0.37,11.63,118.1K
+ALZN,Alzamend Neuro Inc.,2.62,0.27,11.49,481.2K
+IMDX,Insight Molecular Diagnostics Inc.,3.44,0.35,11.33,117.9K
+MCRB,Seres Therapeutics Inc.,17.4,1.71,10.9,154.4K
+PAGS,PagSeguro Digital Ltd. Cl A,10.74,1.04,10.72,11.0M
+CRNC,Cerence Inc.,11.36,1.1,10.72,4.6M
+BREA,Brera Holdings PLC,7.58,0.73,10.66,4.5M
+AREC,American Resources Corp.,2.71,0.26,10.61,6.6M
+BTE,Baytex Energy Corp.,2.61,0.25,10.59,40.2M
+DK,Delek US Holdings Inc.,31.45,2.97,10.43,2.5M
+ADN,Advent Technologies Holdings Inc.,3.19,0.3,10.38,229.7K
+STKH,Steakholder Foods Ltd. ADR,5.47,0.51,10.28,5.4M
+LPL,LG Display Co. Ltd. ADR,4.96,0.46,10.22,998.5K
+PLCE,Children's Place Inc.,7.91,0.72,10.01,830.7K
+CLMT,Calumet Inc.,19.26,1.75,9.99,1.8M
+PXLW,Pixelworks Inc.,11.09,1.0,9.91,102.9K
+CRNT,Ceragon Networks Ltd.,2.23,0.2,9.85,1.3M
+PBF,PBF Energy Inc.,30.62,2.7,9.67,3.6M
+ABCL,AbCellera Biologics Inc.,4.77,0.42,9.66,5.2M
+CRBP,Corbus Pharmaceuticals Holdings Inc.,10.27,0.9,9.61,439.6K
+REBN,Reborn Coffee Inc.,2.74,0.24,9.6,234.7K
+SMHI,SEACOR Marine Holdings Inc.,7.08,0.62,9.6,222.9K
+MLGO,MicroAlgo Inc.,10.01,0.87,9.52,1.3M
+DGXX,Digi Power X Inc.,2.78,0.24,9.45,1.2M
+BE,Bloom Energy Corp.,73.29,6.27,9.36,14.1M
+NUKK,Nukkleus Inc.,5.63,0.48,9.32,18.6M
+CTRM,Castor Maritime Inc.,2.23,0.19,9.32,138.0K
+CMCM,Cheetah Mobile Inc. ADR,8.6,0.73,9.28,117.8K
+ABTC,American Bitcoin Corp.,7.73,0.66,9.26,7.1M
+FBYD,Falcon's Beyond Global Inc.,11.49,0.97,9.22,53.1K
+AMPX,Amprius Technologies Inc.,9.14,0.77,9.2,11.6M
+HUIZ,Huize Holding Ltd. ADR,3.85,0.32,9.07,191.5K
+SKIL,Skillsoft Corp.,14.13,1.17,9.03,110.3K
+PAPL,Pineapple Financial Inc.,6.07,0.5,8.98,107.9K
+CVI,CVR Energy Inc.,33.18,2.71,8.89,2.8M
+STEM,Stem Inc.,16.54,1.35,8.89,345.7K
+CLSK,CleanSpark Inc.,11.2,0.91,8.84,29.6M
+CMPR,Cimpress PLC,62.65,5.06,8.79,517.2K
+DRMA,Dermata Therapeutics Inc.,5.9,0.47,8.75,139.4K
+CURX,Curanex Pharmaceuticals Inc.,9.16,0.73,8.66,4.4M
+JVA,Coffee Holding Co. Inc.,4.78,0.38,8.64,126.7K
+DEVS,DevvStream Corp.,2.9,0.23,8.61,263.4K
+USAR,USA Rare Earth Inc.,14.92,1.18,8.59,9.2M
+YMT,Yimutian Inc. ADR,2.29,0.18,8.53,55.4K
+BW,Babcock & Wilcox Enterprises Inc.,3.2,0.25,8.47,4.6M
+FIGR,Figure Technology Solutions Inc.,40.48,3.15,8.44,8.1M
+ELVR,Sayona Mining Ltd. ADR,17.46,1.35,8.38,146.8K
+PGEN,Precigen Inc.,3.89,0.3,8.36,9.3M
+SDM,Smart Digital Group Ltd.,12.94,0.99,8.28,5.7M
+SEDG,SolarEdge Technologies Inc.,33.11,2.52,8.24,4.7M
+SRTA,Strata Critical Medical Inc. Cl A,4.9,0.37,8.17,1.4M
+NIO,NIO Inc. ADR,7.02,0.53,8.17,130.7M
+AMPY,Amplify Energy Corp.,4.38,0.33,8.15,879.1K
+MARA,MARA Holdings Inc.,17.53,1.29,7.94,112.7M
+KTOS,Kratos Defense & Security Solutions Inc.,76.35,5.61,7.93,5.3M
+FERG,Ferguson Enterprises Inc.,231.54,17.01,7.93,5.0M
+DAR,Darling Ingredients Inc.,33.87,2.48,7.9,5.9M
+SVCO,Silvaco Group Inc.,5.6,0.41,7.9,236.5K
+SPCB,SuperCom Ltd.,11.1,0.81,7.87,122.2K
+GPCR,Structure Therapeutics Inc. ADR,21.79,1.59,7.87,814.6K

--- a/ygainers_normalized.csv
+++ b/ygainers_normalized.csv
@@ -1,0 +1,107 @@
+symbol,company_name,price,change,perc_change,volume
+WBTN,WEBTOON Entertainment Inc.,20.80,+5.84,+39.04,8.747M
+QMMM,QMMM Holdings Limited,88.00,+16.25,+22.65,574276
+BBAI,"BigBear.ai Holdings, Inc.",5.94,+0.85,+16.70,207.011M
+PAGS,PagSeguro Digital Ltd.,10.74,+1.04,+10.72,10.989M
+PBF,PBF Energy Inc.,30.62,+2.70,+9.67,3.638M
+BE,Bloom Energy Corporation,73.29,+6.27,+9.36,13.348M
+ABTC,American Bitcoin Corp,7.73,+0.65,+9.26,6.985M
+CVI,"CVR Energy, Inc.",33.18,+2.71,+8.89,2.838M
+CLSK,"CleanSpark, Inc.",11.20,+0.91,+8.84,29.273M
+FIGR,"Figure Technology Solutions, Inc.",40.48,+3.15,+8.44,8.072M
+NIO,NIO Inc.,7.02,+0.53,+8.17,126.922M
+MARA,"MARA Holdings, Inc.",17.53,+1.29,+7.94,111.67M
+KTOS,"Kratos Defense & Security Solutions, Inc.",76.35,+5.61,+7.93,5.299M
+FERG,Ferguson Enterprises Inc.,231.54,+17.01,+7.93,5.042M
+DAR,Darling Ingredients Inc.,33.87,+2.48,+7.90,5.908M
+BIDU,"Baidu, Inc.",123.79,+8.97,+7.81,11.762M
+BEAM,Beam Therapeutics Inc.,22.91,+1.63,+7.66,3.245M
+APA,APA Corporation,24.51,+1.60,+6.98,11.222M
+VERX,"Vertex, Inc.",25.52,+1.56,+6.51,2.095M
+MUR,Murphy Oil Corporation,27.81,+1.66,+6.35,2.687M
+STLD,"Steel Dynamics, Inc.",139.67,+8.09,+6.15,2.345M
+CIFR,Cipher Mining Inc.,11.51,+0.66,+6.08,30.24M
+AVAV,"AeroVironment, Inc.",265.87,+14.83,+5.91,1.327M
+CRSP,CRISPR Therapeutics AG,61.19,+3.35,+5.79,3.856M
+IONQ,"IonQ, Inc.",62.26,+3.15,+5.33,30.269M
+BMNR,"Bitmine Immersion Technologies, Inc.",55.93,+2.82,+5.31,51.782M
+AMKR,"Amkor Technology, Inc.",27.04,+1.36,+5.30,3.642M
+RIVN,"Rivian Automotive, Inc.",14.32,+0.72,+5.29,62.268M
+RGEN,Repligen Corporation,119.75,+6.01,+5.28,1.338M
+SM,SM Energy Company,27.41,+1.34,+5.14,1.989M
+CRK,"Comstock Resources, Inc.",17.07,+0.83,+5.11,2.248M
+TGS,Transportadora de Gas del Sur S.A.,22.25,+1.07,+5.05,813404
+KLIC,"Kulicke and Soffa Industries, Inc.",41.13,+1.98,+5.04,974937
+OXY,Occidental Petroleum Corporation,47.76,+2.29,+5.04,13.791M
+RIOT,"Riot Platforms, Inc.",17.52,+0.84,+5.04,53.824M
+MENS,Jyong Biotech Ltd.,54.42,+2.60,+5.02,257843
+NOV,NOV Inc.,13.30,+0.60,+4.72,4.008M
+WFRD,Weatherford International plc,64.14,+2.74,+4.46,602739
+TMC,TMC the metals company Inc.,5.67,+0.24,+4.42,7.867M
+CHA,Chagee Holdings Limited,17.27,+0.72,+4.35,1.179M
+WULF,TeraWulf Inc.,10.94,+0.45,+4.29,34.934M
+PAM,Pampa Energía S.A.,61.75,+2.52,+4.25,286989
+TMDX,"TransMedics Group, Inc.",119.15,+4.86,+4.25,702924
+HSY,The Hershey Company,193.45,+7.89,+4.25,2.505M
+ROKU,"Roku, Inc.",97.91,+3.97,+4.23,4.407M
+BG,Bunge Global SA,83.69,+3.39,+4.22,2.43M
+VSEC,VSE Corporation,172.39,+6.91,+4.18,254636
+WIX,Wix.com Ltd.,178.00,+7.13,+4.17,2.252M
+PRCT,PROCEPT BioRobotics Corporation,39.57,+1.57,+4.13,1.413M
+OVV,Ovintiv Inc.,42.35,+1.68,+4.13,3.213M
+HP,"Helmerich & Payne, Inc.",21.77,+0.86,+4.11,1.343M
+RGTI,"Rigetti Computing, Inc.",20.00,+0.79,+4.11,43.318M
+BWIN,"The Baldwin Insurance Group, Inc.",31.31,+1.23,+4.09,1.065M
+CRGY,Crescent Energy Company,8.76,+0.34,+4.04,4.334M
+MRNA,"Moderna, Inc.",24.84,+0.96,+4.02,15.57M
+CHRD,Chord Energy Corporation,106.42,+4.11,+4.02,1.674M
+KVYO,"Klaviyo, Inc.",32.92,+1.27,+4.01,4.498M
+MGY,Magnolia Oil & Gas Corporation,24.61,+0.94,+3.97,2.454M
+PTEN,"Patterson-UTI Energy, Inc.",5.62,+0.21,+3.88,5.941M
+FORM,"FormFactor, Inc.",31.90,+1.18,+3.84,953756
+ENVA,"Enova International, Inc.",121.13,+4.47,+3.83,684396
+YPF,YPF Sociedad Anónima,27.71,+1.02,+3.82,1.55M
+STVN,Stevanato Group S.p.A.,27.23,+1.00,+3.81,445272
+SNAP,Snap Inc.,7.74,+0.28,+3.75,147.757M
+BRKR,Bruker Corporation,33.26,+1.19,+3.71,3.645M
+GGAL,Grupo Financiero Galicia S.A.,30.25,+1.07,+3.67,1.583M
+FOLD,"Amicus Therapeutics, Inc.",8.01,+0.28,+3.62,7.337M
+ONTO,Onto Innovation Inc.,120.58,+4.21,+3.62,2.451M
+CIVI,"Civitas Resources, Inc.",33.56,+1.17,+3.61,1.907M
+QBTS,D-Wave Quantum Inc.,18.98,+0.66,+3.60,37.953M
+SKY,"Champion Homes, Inc.",77.97,+2.69,+3.57,1.157M
+CSAN,Cosan S.A.,5.82,+0.20,+3.56,1.946M
+DVN,Devon Energy Corporation,34.97,+1.20,+3.55,7.799M
+RH,RH,230.70,+7.87,+3.53,916307
+SOUN,"SoundHound AI, Inc.",14.69,+0.50,+3.52,65.978M
+BRBR,"BellRing Brands, Inc.",36.75,+1.24,+3.49,2.614M
+VIST,"Vista Energy, S.A.B. de C.V.",36.65,+1.23,+3.47,810157
+GLXY,Galaxy Digital,31.83,+1.06,+3.44,9.35M
+NE,Noble Corporation plc,31.60,+1.05,+3.44,2.823M
+SITM,SiTime Corporation,288.61,+9.48,+3.39,490112
+SAM,"The Boston Beer Company, Inc.",222.35,+7.24,+3.37,336272
+CGON,"CG Oncology, Inc.",35.76,+1.16,+3.35,1.426M
+MLYS,"Mineralys Therapeutics, Inc.",37.42,+1.21,+3.34,1.301M
+CHWY,"Chewy, Inc.",38.18,+1.23,+3.33,10.388M
+NOG,"Northern Oil and Gas, Inc.",25.79,+0.83,+3.33,1.549M
+TCOM,Trip.com Group Limited,76.58,+2.46,+3.32,4.216M
+BMA,Banco Macro S.A.,43.85,+1.40,+3.30,498144
+VG,"Venture Global, Inc.",14.10,+0.45,+3.30,6.58M
+SMPL,The Simply Good Foods Company,27.00,+0.86,+3.29,1.887M
+ALKS,Alkermes plc,27.39,+0.87,+3.28,2.087M
+DLO,DLocal Limited,14.64,+0.46,+3.24,4.091M
+ALAB,"Astera Labs, Inc.",238.79,+7.50,+3.24,4.365M
+JD,"JD.com, Inc.",34.71,+1.09,+3.24,27.59M
+VLO,Valero Energy Corporation,162.64,+5.07,+3.22,2.919M
+MTDR,Matador Resources Company,47.98,+1.49,+3.20,2.027M
+RELY,"Remitly Global, Inc.",17.20,+0.53,+3.18,4.058M
+GME,GameStop Corp.,26.34,+0.81,+3.17,9.783M
+KYMR,"Kymera Therapeutics, Inc.",48.78,+1.50,+3.17,894833
+SGHC,Super Group (SGHC) Limited,13.09,+0.40,+3.15,4.474M
+RNA,"Avidity Biosciences, Inc.",41.44,+1.25,+3.11,2.078M
+SDRL,Seadrill Limited,34.03,+1.02,+3.09,724234
+PSIX,"Power Solutions International, Inc.",98.42,+2.89,+3.03,579100
+ON,ON Semiconductor Corporation,49.56,+1.45,+3.01,8.156M
+ADM,Archer-Daniels-Midland Company,62.35,+1.82,+3.01,4.665M
+PONY,Pony AI Inc.,17.13,+0.50,+3.01,11.148M
+,,nan,,,


### PR DESCRIPTION
## Summary
This PR adds a normalizer function for Yahoo Finance and WSJ gainers tables and documents how to run and verify.

- Added bin/normalize_gainers.py with two functions:
  - normalize_yahoo(csv_path) → outputs ygainers_normalized.csv
  - normalize_wsj(csv_path) → outputs wsjgainers_normalized.csv
- Updated .gitignore to ignore raw HTML/CSV scrape artifacts
- Verified outputs contain expected columns:
  symbol, company_name, price, change, perc_change, volume
- Tested by running:
  make ygainers.csv
  make wsjgainers.csv
  python bin/normalize_gainers.py

## Lab Link
[LabM02: Gainers Normalization](https://github.com/EfrainOlivaresUVA/2508_DS5111_materials/blob/main/labs/LAB-MO2_branching.md)

## How I Tested
**Environment**
```bash
source env/bin/activate
pip install -r requirements.txt
pip install pandas lxml html5lib

I pulled Python from bash and called the functions to test with each CSV file

from bin.normalize_gainers import normalize_yahoo, normalize_wsj

normalize_yahoo("ygainers.csv")
PosixPath('ygainers_normalized.csv')
>>> normalize_wsj("wsjgainers.csv")
PosixPath('wsjgainers_normalized.csv')
